### PR TITLE
Catch to not include print and summary file names in calls to snSet

### DIFF
--- a/src/Snopt.jl
+++ b/src/Snopt.jl
@@ -267,15 +267,19 @@ function setoptions(options, work)
         errors[1] = 0
 
         if typeof(value) == String
+            # snSet is intended for string containing both the key and value in the string, 
+            # not for when the value alone is a string. File names are handled separately
+            # for more information please see 
+            # https://web.stanford.edu/group/SOL/guides/sndoc7.pdf page 66 (sec 7.5).
 
-            value = string(value, repeat(" ", 72-length(value)))
-
-            ccall( (:snset_, snoptlib), Nothing,
-                (Ptr{Cuchar}, Ref{Cint}, Ref{Cint}, Ptr{Cint},
-                Ptr{Cuchar}, Ref{Cint}, Ptr{Cint}, Ref{Cint}, Ptr{Cdouble}, Ref{Cint}),
-                value, PRINTNUM, SUMNUM, errors,
-                work.cw, work.lencw, work.iw, work.leniw, work.rw, work.lenrw)
-
+            if key != "Print file" && key != "Summary file" 
+                value = string(value, repeat(" ", 72-length(value)))
+                ccall( (:snset_, snoptlib), Nothing,
+                    (Ptr{Cuchar}, Ref{Cint}, Ref{Cint}, Ptr{Cint},
+                    Ptr{Cuchar}, Ref{Cint}, Ptr{Cint}, Ref{Cint}, Ptr{Cdouble}, Ref{Cint}),
+                    value, PRINTNUM, SUMNUM, errors,
+                    work.cw, work.lencw, work.iw, work.leniw, work.rw, work.lenrw)
+            end
         elseif isinteger(value)
 
             ccall( (:snseti_, snoptlib), Nothing,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,7 +331,8 @@ end # sparse test set
     @test info == "Finished successfully: optimality conditions satisfied"
 end
 
-# test to check options
+# -----------------------------------------
+
 @testset "files" begin
     function matyas(g, df, dg, x, deriv)
         f = 0.26 * (x[1]^2 + x[2]^2) - 0.48 * x[1] * x[2]
@@ -363,4 +364,5 @@ end
     # remove generated files
     rm(print_file)
     rm(summary_file)
-end
+    
+end # file generation test set

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -330,3 +330,37 @@ end # sparse test set
     @test isapprox(fopt, 0.0; atol=1e-3)
     @test info == "Finished successfully: optimality conditions satisfied"
 end
+
+# test to check options
+@testset "files" begin
+    function matyas(g, df, dg, x, deriv)
+        f = 0.26 * (x[1]^2 + x[2]^2) - 0.48 * x[1] * x[2]
+        fail = false
+        return f, fail
+    end
+    x0 = [5.0; 7]
+    lx = [-10.0; -10]
+    ux = [10.0; 10]
+    lg = []
+    ug = []
+    rows = []
+    cols = [] 
+
+    print_file = "snopt-print-test.out"
+    summary_file = "snopt-summary-test.out"
+   
+    options = Dict(
+        "Print file" => print_file,
+        "Summary file" => summary_file
+    )
+    
+    xopt, fopt, info, out = snopta(matyas, x0, lx, ux, lg, ug, rows, cols, options)
+
+    # test that files were properly generated
+    @test isfile(print_file)
+    @test isfile(summary_file)
+
+    # remove generated files
+    rm(print_file)
+    rm(summary_file)
+end


### PR DESCRIPTION
snSet is intended for strings containing both the key and value in the string, not for when the value alone is a string. File names are handled separately and do not need to be set with snSet. For more information please see https://web.stanford.edu/group/SOL/guides/sndoc7.pdf page 66 (sec 7.5).

The catalyst for the change was to suppress warnings due to errors returned by calls to snSet that in practice should not have been made in the first place.
