### PR TITLE
Save SNOPT info code in output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Snopt"
 uuid = "0e9dc826-d618-11e8-1f57-c34e87fde2c0"
 authors = ["Andrew Ning <aning@byu.edu> and contributors"]
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Snopt"
 uuid = "0e9dc826-d618-11e8-1f57-c34e87fde2c0"
 authors = ["Andrew Ning <aning@byu.edu> and contributors"]
-version = "0.3.0"
+version = "0.2.3"
 
 [deps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/Snopt.jl
+++ b/src/Snopt.jl
@@ -165,7 +165,7 @@ Workspace(lenc, leni, lenr) = Workspace(
 )
 
 """
-    Outputs(gstar, iterations, major_iter, run_time, nInf, sInf, warm)
+    Outputs(gstar, iterations, major_iter, run_time, nInf, sInf, warm, info_code)
 
 Outputs returned by the snopta function.
 
@@ -177,6 +177,7 @@ Outputs returned by the snopta function.
 - `nInf::Int`: number of infeasibility constraints, see snopta docs
 - `sInf::Float`: sum of infeasibility constraints, see snopta docs
 - `warm::WarmStart`: a warm start object that can be used in a restart.
+- `info_code::Int`: snopta `INFO` exit status code
 """
 struct Outputs{TF,TI,TW}
     gstar::Vector{TF}
@@ -186,6 +187,7 @@ struct Outputs{TF,TI,TW}
     nInf::TI
     sInf::TF
     warm::TW
+    info_code::TI
 end
 
 
@@ -611,7 +613,7 @@ function snopta(func!, start::Start, lx, ux, lg, ug, rows, cols,
     start.xmul, start.fmul)
 
     out = Outputs(start.f[2:end], work.iw[421], work.iw[422], work.rw[462], 
-        nInf[1], sInf[1], warm)
+        nInf[1], sInf[1], warm, INFO[1])
 
     return start.x, start.f[1], codes[INFO[1]], out
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -328,6 +328,10 @@ end # sparse test set
     @test isapprox(xopt[1], 0.0; atol=1e-4)
     @test isapprox(xopt[2], 0.0; atol=1e-4)
     @test isapprox(fopt, 0.0; atol=1e-3)
+
+    # Test that we got a successful info code.
+    @test out.info_code == 1
+
     @test info == "Finished successfully: optimality conditions satisfied"
 end
 
@@ -356,6 +360,9 @@ end
     )
     
     xopt, fopt, info, out = snopta(matyas, x0, lx, ux, lg, ug, rows, cols, options)
+
+    # Test that we got a successful info code.
+    @test out.info_code == 1
 
     # test that files were properly generated
     @test isfile(print_file)


### PR DESCRIPTION
Thanks for Snopt.jl, I've been using it a bunch.

This small PR adds the SNOPT info code (i.e. the `1` in `0/1` or the `41` in `40/41` to the `Outputs` struct.