### PR TITLE
Allow printing of output files to be suppressed and terminal output

### DIFF
--- a/deps/src/fileio.f90
+++ b/deps/src/fileio.f90
@@ -1,32 +1,62 @@
-subroutine openfile(funit, ferror, fname)
+module SNOPT_Julia_c
 
-    ! inputs
-    integer, intent(in) :: funit
-    character*250, intent(in) :: fname
+    use iso_c_binding
+    use iso_fortran_env
 
-    ! outputs
-    integer, intent(out) :: ferror
+    implicit none
 
-    open(funit, file=fname, action='write', status='replace', iostat=ferror)
+    private :: copy_a2s
 
-end subroutine
+contains
 
+    subroutine openfile(funit, ferror, fname, len_fname) bind(C, name = "SNOPT_openfile")
 
-subroutine closefile(funit)
+        ! inputs
+        integer(kind = c_int), intent(in) :: funit
+        character(kind = c_char), dimension(*), intent(in) :: fname
+        integer(kind = c_int), intent(in) :: len_fname
+        ! character*250, intent(in) :: fname
 
-    ! inputs
-    integer, intent(in) :: funit
+        ! outputs
+        integer(kind = c_int), intent(out) :: ferror
 
-    close(funit)
+        open(funit, file = copy_a2s(fname(1:len_fname)), action = 'write', status = 'replace', iostat = ferror)
 
-end subroutine
+    end subroutine
 
+    function get_stdout() bind(C, name = "SNOPT_get_stdout")
+        ! output
+        integer(kind = c_int) :: get_stdout
+        get_stdout = output_unit
+    end function
 
-subroutine flushfile(funit)
+    subroutine closefile(funit) bind(C, name = "SNOPT_closefile")
 
-    ! inputs
-    integer, intent(in) :: funit
+        ! inputs
+        integer(kind = c_int), intent(in) :: funit
 
-    flush(funit)
+        close(funit)
 
-end subroutine
+    end subroutine
+
+    subroutine flushfile(funit) bind(C, name = "SNOPT_flushfile")
+
+        ! inputs
+        integer(kind = c_int), intent(in) :: funit
+
+        flush(funit)
+
+    end subroutine
+
+    pure function copy_a2s(a) result(s)
+        character(kind = c_char), intent(in) :: a(:)
+        character(size(a)) :: s
+        integer :: i
+        s = ''
+        do i = 1, size(a)
+            if (a(i) == c_null_char) exit
+            s(i:i) = a(i)
+        end do
+    end function
+
+end module

--- a/deps/src/fileio.f90
+++ b/deps/src/fileio.f90
@@ -1,36 +1,32 @@
-subroutine openfiles(printnum, sumnum, printerr, sumerr, printfile, sumfile)
+subroutine openfile(funit, ferror, fname)
 
     ! inputs
-    integer, intent(in) :: printnum, sumnum
-    character*250, intent(in) :: printfile, sumfile
+    integer, intent(in) :: funit
+    character*250, intent(in) :: fname
 
     ! outputs
-    integer, intent(out) :: printerr, sumerr
+    integer, intent(out) :: ferror
 
-    open(printnum, file=printfile, action='write', status='replace', iostat=printerr)
-    open(sumnum, file=sumfile, action='write', status='replace', iostat=sumerr)
-
+    open(funit, file=fname, action='write', status='replace', iostat=ferror)
 
 end subroutine
 
 
-subroutine closefiles(printnum, sumnum)
+subroutine closefile(funit)
 
     ! inputs
-    integer, intent(in) :: printnum, sumnum
+    integer, intent(in) :: funit
 
-    close(printnum)
-    close(sumnum)
+    close(funit)
 
 end subroutine
 
 
-subroutine flushfiles(printnum, sumnum)
+subroutine flushfile(funit)
 
     ! inputs
-    integer, intent(in) :: printnum, sumnum
+    integer, intent(in) :: funit
 
-    flush(printnum)
-    flush(sumnum)
+    flush(funit)
 
 end subroutine


### PR DESCRIPTION
This allows the print and/or summary file output to be suppressed whenever `Print file` and `Summary file` are set to empty strings. E.g. `options = Dict("Print file" => "", "Summary file" => "")`.
